### PR TITLE
fix(clash-verge-rev): wrong sha256 of arm

### DIFF
--- a/Casks/clash-verge-rev.rb
+++ b/Casks/clash-verge-rev.rb
@@ -2,7 +2,7 @@ cask "clash-verge-rev" do
   arch arm: "aarch64", intel: "x64"
 
   version "1.4.5"
-  sha256 arm:   "30c58b3297f407ea3296a0e05f45e263bec98ed695e6b859244df2ebf60f93b1",
+  sha256 arm:   "8bed897701070b75df29817986904fe54ae0a0521b8961b32b3cf4ecadadb260",
          intel: "841d8f6d5c5b7e997636c51adaeee8a48a64fa22a03a3da064bb885578a01bff"
 
   url "https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v#{version}/Clash.Verge_#{version}_#{arch}.dmg"


### PR DESCRIPTION
![image](https://github.com/Brewforge/homebrew-chinese/assets/26829325/c2ec9db8-8585-47c9-8825-99f9fa8d8992)
