### PR TITLE
Replace TUNA w/ BFSU

### DIFF
--- a/Casks/basictex-cn.rb
+++ b/Casks/basictex-cn.rb
@@ -2,14 +2,14 @@ cask "basictex-cn" do
   version "2024.0309"
   sha256 "42595c82f36b9271872e917a821b642f83831e867fe86bae5f6ab15f2fea350b"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/CTAN/systems/mac/mactex/mactex-basictex-#{version.no_dots}.pkg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/CTAN/systems/mac/mactex/"
+  url "https://mirrors.bfsu.edu.cn/CTAN/systems/mac/mactex/mactex-basictex-#{version.no_dots}.pkg",
+      verified: "mirrors.bfsu.edu.cn/CTAN/systems/mac/mactex/"
   name "BasicTeX"
   desc "Compact TeX distribution as alternative to the full TeX Live / MacTeX"
   homepage "https://www.tug.org/mactex/morepackages.html"
 
   livecheck do
-    url "https://mirrors.tuna.tsinghua.edu.cn/CTAN/systems/mac/mactex"
+    url "https://mirrors.bfsu.edu.cn/CTAN/systems/mac/mactex"
     strategy :page_match do |page|
       match = page.match(/href=.*?mactex-basictex-(\d{4})(\d{2})(\d{2})\.pkg/)
       next if match.blank?

--- a/Casks/blender-cn.rb
+++ b/Casks/blender-cn.rb
@@ -5,8 +5,8 @@ cask "blender-cn" do
   sha256 arm:   "241dbfa6dac2c3b5e15bb1c132e0fcf16f7bf6e5bf3959440b6c8052b7b26d08",
          intel: "ca987d61b70cc3f8c292f575d1694c8dded48a217476f8e25502879eb3ded293"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/blender/release/Blender#{version.major_minor}/blender-#{version}-macos-#{arch}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/"
+  url "https://mirrors.bfsu.edu.cn/blender/release/Blender#{version.major_minor}/blender-#{version}-macos-#{arch}.dmg",
+      verified: "mirrors.bfsu.edu.cn/"
   name "Blender"
   desc "3D creation suite"
   homepage "https://www.blender.org/"

--- a/Casks/freecad-cn.rb
+++ b/Casks/freecad-cn.rb
@@ -5,14 +5,14 @@ cask "freecad-cn" do
   sha256 arm:   "88f51e816075c586bcde89eab0b5edc4a260294eefc11bf5a917d7818330ad50",
          intel: "e22dfd804c2b09aa559cd3ec2de6e1d7321022c04a354857fc9936b7b6d2e5bb"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/github-release/FreeCAD/FreeCAD/FreeCAD%20#{version}/FreeCAD-#{version}-macOS-#{arch}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/github-release/FreeCAD/FreeCAD/"
+  url "https://mirrors.bfsu.edu.cn/github-release/FreeCAD/FreeCAD/FreeCAD%20#{version}/FreeCAD-#{version}-macOS-#{arch}.dmg",
+      verified: "mirrors.bfsu.edu.cn/github-release/FreeCAD/FreeCAD/"
   name "FreeCAD"
   desc "3D parametric modeler"
   homepage "https://www.freecadweb.org/"
 
   livecheck do
-    url "https://mirrors.tuna.tsinghua.edu.cn/github-release/FreeCAD/FreeCAD/"
+    url "https://mirrors.bfsu.edu.cn/github-release/FreeCAD/FreeCAD/"
     regex(/FreeCAD v?(\d+(\.\d+){2})/i)
   end
 

--- a/Casks/iina-cn.rb
+++ b/Casks/iina-cn.rb
@@ -2,14 +2,14 @@ cask "iina-cn" do
   version "1.3.5"
   sha256 "3b8b9199f41a18c2aa8b30e5824d0c9daccc1d59176832ea650f533fcbdc6a38"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/iina/IINA.v#{version}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/iina/"
+  url "https://mirrors.bfsu.edu.cn/iina/IINA.v#{version}.dmg",
+      verified: "mirrors.bfsu.edu.cn/iina/"
   name "IINA"
   desc "Free and open-source media player"
   homepage "https://iina.io/"
 
   livecheck do
-    url "https://mirrors.tuna.tsinghua.edu.cn/iina"
+    url "https://mirrors.bfsu.edu.cn/iina"
     regex(/IINA\.v(\d+(\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/julia-cn.rb
+++ b/Casks/julia-cn.rb
@@ -5,8 +5,8 @@ cask "julia-cn" do
   sha256 arm:   "f05c042d7bf42807da13ebdd27d1c217d2ee2a42294f7e5cbd61546f11d3dd1e",
          intel: "19e419ae40d798f0445b7e3ca875e11bd4f8ffd95ae83c818a08a7f5a41bafef"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/julia-releases/bin/mac/#{arch}/#{version.major_minor}/julia-#{version}-mac#{arch.delete_prefix("x")}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/julia-releases/bin/mac/"
+  url "https://mirrors.bfsu.edu.cn/julia-releases/bin/mac/#{arch}/#{version.major_minor}/julia-#{version}-mac#{arch.delete_prefix("x")}.dmg",
+      verified: "mirrors.bfsu.edu.cn/julia-releases/bin/mac/"
   name "Julia"
   desc "Programming language for technical computing"
   homepage "https://julialang.org/"

--- a/Casks/kicad-cn.rb
+++ b/Casks/kicad-cn.rb
@@ -2,14 +2,14 @@ cask "kicad-cn" do
   version "8.0.4"
   sha256 "30bbb7771d8e279f625d08632c02636e79f15f67006ae6e0cb5828fc698821e8"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/kicad/osx/stable/kicad-unified-universal-#{version}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/kicad/"
+  url "https://mirrors.bfsu.edu.cn/kicad/osx/stable/kicad-unified-universal-#{version}.dmg",
+      verified: "mirrors.bfsu.edu.cn/kicad/"
   name "KiCad"
   desc "Electronics design automation suite"
   homepage "https://kicad.org/"
 
   livecheck do
-    url "https://mirrors.tuna.tsinghua.edu.cn/kicad/osx/stable/"
+    url "https://mirrors.bfsu.edu.cn/kicad/osx/stable/"
     regex(/kicad-unified-universal-(\d+(?:\.\d+)+(-rc\d+)?)/i)
   end
 

--- a/Casks/libreoffice-cn.rb
+++ b/Casks/libreoffice-cn.rb
@@ -6,8 +6,8 @@ cask "libreoffice-cn" do
   sha256 arm:   "4e655f5e7eab065bf792f7826edaea8de29d822e853826b45047f42a2a4fed8d",
          intel: "838d775690901b866f805d2bf00f2538eee9416723a326f70b31c8f1c8447646"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/libreoffice/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/libreoffice/libreoffice/stable/"
+  url "https://mirrors.bfsu.edu.cn/libreoffice/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg",
+      verified: "mirrors.bfsu.edu.cn/libreoffice/libreoffice/stable/"
   name "LibreOffice"
   desc "Office suite"
   homepage "https://www.libreoffice.org/"

--- a/Casks/lyx-cn.rb
+++ b/Casks/lyx-cn.rb
@@ -2,8 +2,8 @@ cask "lyx-cn" do
   version "2.4.1"
   sha256 "978498962f281d47264581027dc033e05a88c200970c3847ed99bd650af5d62f"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/lyx/bin/#{version.major_minor_patch}/LyX-#{version}+qt5-x86_64-arm64-cocoa.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/lyx/bin/"
+  url "https://mirrors.bfsu.edu.cn/lyx/bin/#{version.major_minor_patch}/LyX-#{version}+qt5-x86_64-arm64-cocoa.dmg",
+      verified: "mirrors.bfsu.edu.cn/lyx/bin/"
   name "LyX"
   desc "GUI document processor based on the LaTeX typesetting system"
   homepage "https://www.lyx.org/"

--- a/Casks/mambaforge-cn.rb
+++ b/Casks/mambaforge-cn.rb
@@ -5,14 +5,14 @@ cask "mambaforge-cn" do
   sha256 arm:   "de7c7f229d05104de802f1f729a595736b08139c4ae59ba8ba0049050d63c98f",
          intel: "5455900cf1298f21333b7c0d1ec159952e1ef5426563cc97eb7e42053d608afc"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/github-release/conda-forge/miniforge/LatestRelease/Mambaforge-#{version}-MacOSX-#{arch}.sh",
-      verified: "mirrors.tuna.tsinghua.edu.cn/github-release/conda-forge/miniforge/"
+  url "https://mirrors.bfsu.edu.cn/github-release/conda-forge/miniforge/LatestRelease/Mambaforge-#{version}-MacOSX-#{arch}.sh",
+      verified: "mirrors.bfsu.edu.cn/github-release/conda-forge/miniforge/"
   name "mambaforge"
   desc "Minimal installer for conda with preinstalled support for Mamba"
   homepage "https://github.com/conda-forge/miniforge"
 
   livecheck do
-    url "https://mirrors.tuna.tsinghua.edu.cn/github-release/conda-forge/miniforge/LatestRelease"
+    url "https://mirrors.bfsu.edu.cn/github-release/conda-forge/miniforge/LatestRelease"
     regex(/Mambaforge-(\d+(?:[.-]\d+)+)-MacOSX-#{arch}\.sh/i)
   end
 

--- a/Casks/miniforge-cn.rb
+++ b/Casks/miniforge-cn.rb
@@ -5,14 +5,14 @@ cask "miniforge-cn" do
   sha256 arm:   "9b3c3d9fa30437592e680390f2b27d45c5d5cfcbfad9a1af233f70a6d8be71a1",
          intel: "26a80621b146d60e5ae0d896b83ec138416653b951286361b1f93a804cb6a8d9"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/github-release/conda-forge/miniforge/LatestRelease/Miniforge3-#{version}-MacOSX-#{arch}.sh",
-      verified: "mirrors.tuna.tsinghua.edu.cn/github-release/conda-forge/miniforge/"
+  url "https://mirrors.bfsu.edu.cn/github-release/conda-forge/miniforge/LatestRelease/Miniforge3-#{version}-MacOSX-#{arch}.sh",
+      verified: "mirrors.bfsu.edu.cn/github-release/conda-forge/miniforge/"
   name "miniforge"
   desc "Minimal installer for conda specific to conda-forge"
   homepage "https://github.com/conda-forge/miniforge"
 
   livecheck do
-    url "https://mirrors.tuna.tsinghua.edu.cn/github-release/conda-forge/miniforge/LatestRelease"
+    url "https://mirrors.bfsu.edu.cn/github-release/conda-forge/miniforge/LatestRelease"
     regex(/Miniforge3-(\d+(?:[.-]\d+)+)-MacOSX-#{arch}\.sh/i)
   end
 

--- a/Casks/obs-cn.rb
+++ b/Casks/obs-cn.rb
@@ -6,14 +6,14 @@ cask "obs-cn" do
   sha256 arm:   "160f24804f8c70bd70d88ab0c9c8dcc4e88bc42c5c53e2705ced3216a434be96",
          intel: "0bea96aea2a5cb4fc1ab3b24ae3677ccf5542c10cd2d610264f4a39dd582c67b"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/github-release/obsproject/obs-studio/LatestRelease/OBS-Studio-#{version}-macOS-#{arch}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/"
+  url "https://mirrors.bfsu.edu.cn/github-release/obsproject/obs-studio/LatestRelease/OBS-Studio-#{version}-macOS-#{arch}.dmg",
+      verified: "mirrors.bfsu.edu.cn/"
   name "OBS"
   desc "Open-source software for live streaming and screen recording"
   homepage "https://obsproject.com/"
 
   livecheck do
-    url "https://mirrors.tuna.tsinghua.edu.cn/github-release/obsproject/obs-studio/LatestRelease"
+    url "https://mirrors.bfsu.edu.cn/github-release/obsproject/obs-studio/LatestRelease"
     regex(/OBS-Studio-(\d+(\.\d+){2})-macos-#{arch}\.dmg/i)
   end
 

--- a/Casks/qt-creator-cn.rb
+++ b/Casks/qt-creator-cn.rb
@@ -2,14 +2,14 @@ cask "qt-creator-cn" do
   version "13.0.2"
   sha256 "62b693289102f993d82b39443a783d3b080512b3334db5241c01dcce20b87432"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/qt/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/"
+  url "https://mirrors.bfsu.edu.cn/qt/official_releases/qtcreator/#{version.major_minor}/#{version}/qt-creator-opensource-mac-x86_64-#{version}.dmg",
+      verified: "mirrors.bfsu.edu.cn/"
   name "Qt Creator"
   desc "IDE for application development"
   homepage "https://www.qt.io/developers/"
 
   livecheck do
-    url "https://mirrors.tuna.tsinghua.edu.cn/qt/official_releases/qtcreator/latest/"
+    url "https://mirrors.bfsu.edu.cn/qt/official_releases/qtcreator/latest/"
     regex(/qt-creator-opensource-mac-x86_64-(.\d+(\.\d+)+)\.dmg/i)
   end
 

--- a/Casks/texstudio-cn.rb
+++ b/Casks/texstudio-cn.rb
@@ -2,14 +2,14 @@ cask "texstudio-cn" do
   version "4.8.1"
   sha256 "9e547180b3013624a61ea5dbc92deac64ed6573d217f6044ccdf0b442932d513"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/github-release/texstudio-org/texstudio/LatestRelease/texstudio-#{version}-osx.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/github-release/texstudio-org/"
+  url "https://mirrors.bfsu.edu.cn/github-release/texstudio-org/texstudio/LatestRelease/texstudio-#{version}-osx.dmg",
+      verified: "mirrors.bfsu.edu.cn/github-release/texstudio-org/"
   name "TeXstudio"
   desc "LaTeX editor"
   homepage "https://github.com/texstudio-org/texstudio/"
 
   livecheck do
-    url "https://mirrors.tuna.tsinghua.edu.cn/github-release/texstudio-org/texstudio/LatestRelease"
+    url "https://mirrors.bfsu.edu.cn/github-release/texstudio-org/texstudio/LatestRelease"
     regex(/texstudio-(\d+(\.\d+){2})-osx\.dmg/i)
   end
 

--- a/Casks/vlc-cn.rb
+++ b/Casks/vlc-cn.rb
@@ -5,14 +5,14 @@ cask "vlc-cn" do
   sha256 arm:   "15dd65bf6489da9ec6a67f5585c74c40a58993acff41a82958a916dd74178044",
          intel: "d431fd051c3dc7af02bd313c6d05d90cf604b70ed3ec5bba6fd4c49ef3e638d9"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/videolan-ftp/vlc/last/macosx/vlc-#{version}-#{arch}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/videolan-ftp/vlc/"
+  url "https://mirrors.bfsu.edu.cn/videolan-ftp/vlc/last/macosx/vlc-#{version}-#{arch}.dmg",
+      verified: "mirrors.bfsu.edu.cn/videolan-ftp/vlc/"
   name "VLC media player"
   desc "Multimedia player"
   homepage "https://www.videolan.org/vlc/"
 
   livecheck do
-    url "https://mirrors.tuna.tsinghua.edu.cn/videolan-ftp/vlc/last/macosx"
+    url "https://mirrors.bfsu.edu.cn/videolan-ftp/vlc/last/macosx"
     regex(/vlc-(\d+(\.\d+){2})-#{arch}\.dmg/i)
   end
 

--- a/Casks/vscodium-cn.rb
+++ b/Casks/vscodium-cn.rb
@@ -5,14 +5,14 @@ cask "vscodium-cn" do
   sha256 arm:   "073bd32e09aca9c5895640466dde8f1cdb77e134f44d60e5220bec60c36151fb",
          intel: "1f9bdc909335359d76b5c9a3d1aaa45d4aa0ca3058abf25a9c445546de011877"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/github-release/VSCodium/vscodium/LatestRelease/VSCodium.#{arch}.#{version}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/"
+  url "https://mirrors.bfsu.edu.cn/github-release/VSCodium/vscodium/LatestRelease/VSCodium.#{arch}.#{version}.dmg",
+      verified: "mirrors.bfsu.edu.cn/"
   name "VSCodium"
   desc "Binary releases of VS Code without MS branding/telemetry/licensing"
   homepage "https://github.com/VSCodium/vscodium"
 
   livecheck do
-    url "https://mirrors.tuna.tsinghua.edu.cn/github-release/VSCodium/vscodium/LatestRelease"
+    url "https://mirrors.bfsu.edu.cn/github-release/VSCodium/vscodium/LatestRelease"
     regex(/VSCodium\.#{arch}\.(\d+(\.\d+)+)\.dmg/i)
   end
 


### PR DESCRIPTION
The TUNA mirror has been overloaded:

https://mirrors.tuna.tsinghua.edu.cn/status/#server-status

<img width="1384" alt="image" src="https://github.com/user-attachments/assets/d02b78ee-c9d7-4ab7-b6a9-c239fe94f977">

And there is the BFSU mirror (https://mirrors.bfsu.edu.cn), powered by BFSU's infrastructure and maintained by the TUNA, and is underloaded:

https://mirrors.bfsu.edu.cn/status/#server-status

<img width="1408" alt="image" src="https://github.com/user-attachments/assets/a8375997-c636-4404-a6fc-7c3a64bab9ad">

The PR replaces the TUNA mirror with the BFSU mirror.