### PR TITLE
fix: fix bbdown url parse issue

### DIFF
--- a/Formula/bbdown.rb
+++ b/Formula/bbdown.rb
@@ -1,8 +1,8 @@
 class Bbdown < Formula
   desc "Bilibili Downloader"
   homepage "https://github.com/nilaoda/BBDown"
-  url "https://github.com/nilaoda/BBDown/releases/download/#{version.to_s.split(",")[0]}/BBDown_#{version.to_s.tr(",", "_")}_#{OS.mac? ? "osx" : "linux"}-#{Hardware::CPU.arm? ? "arm64" : "x64"}.zip"
   version "1.6.2,20240512"
+  url "https://github.com/nilaoda/BBDown/releases/download/#{version.to_s.split(",")[0]}/BBDown_#{version.to_s.tr(",", "_")}_#{OS.mac? ? "osx" : "linux"}-#{Hardware::CPU.arm? ? "arm64" : "x64"}.zip"
   license "MIT"
 
   if OS.mac? && Hardware::CPU.arm?


### PR DESCRIPTION
Fix bbdown download url parse error 

Before:

<img width="801" alt="image" src="https://github.com/user-attachments/assets/b96de50d-e61b-4adf-a223-3e492281bd7a">


After:

<img width="914" alt="image" src="https://github.com/user-attachments/assets/3d731c5c-e379-4c02-92ad-3b3d6b8ff952">

