### PR TITLE
No autoupdates for clashx-meta

### DIFF
--- a/Casks/c/clashx-meta.rb
+++ b/Casks/c/clashx-meta.rb
@@ -12,8 +12,6 @@ cask "clashx-meta" do
     strategy :github_latest
   end
 
-  auto_updates true
-
   app "ClashX Meta.app"
 
   preflight do


### PR DESCRIPTION
ClashX Meta 检测到更新之后还是会让你去github上下载，这种情况不应该标记为 auto_updates 吧