### PR TITLE
Add Tiny RDM cask

### DIFF
--- a/Casks/t/tiny-rdm.rb
+++ b/Casks/t/tiny-rdm.rb
@@ -1,0 +1,34 @@
+cask "tiny-rdm" do
+  arch arm: "arm64", intel: "intel"
+
+  version "1.2.7"
+  sha256 arm:   "aaebc58a1f97505743bf05f2ab1cfc5e7c3e5841d90266ad836eaab74435f1a3",
+         intel: "3d8e61fa474ae50b61e41a623841fcdd7629615fa105758f2840fff75fe857ad"
+
+  url "https://github.com/tiny-craft/tiny-rdm/releases/download/v#{version}/TinyRDM_#{version}_mac_#{arch}.dmg",
+      verified: "github.com/tiny-craft/tiny-rdm/"
+  name "Tiny RDM"
+  desc "Redis desktop manager"
+  homepage "https://redis.tinycraft.cc/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :big_sur"
+
+  app "Tiny RDM.app"
+
+  preflight do
+    system_command "xattr",
+                   args: ["-cr", "#{staged_path}/Tiny RDM.app"]
+  end
+
+  zap trash: [
+    "~/Library/Application Support/Tiny RDM",
+    "~/Library/Caches/Tiny RDM",
+    "~/Library/Preferences/com.tinycraft.tinyrdm.plist",
+    "~/Library/Saved Application State/com.tinycraft.tinyrdm.savedState",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ brew help
 | `quarkclouddrive`  |                 [夸克网盘](https://pan.quark.cn)                 |                   ![b](assets/b.svg)![1](assets/1.svg)                   |
 |  `splayer-imsyy`   |           [SPlayer](https://github.com/imsyy/SPlayer)            |                   ![a](assets/a.svg)![1](assets/1.svg)                   |
 |   `tts-vue-next`   |       [TTS-Vue-Next](https://tts-doc.loker.vip/home.html)        |                   ![a](assets/a.svg)![1](assets/1.svg)                   |
+|     `tiny-rdm`     |             [Tiny RDM](https://redis.tinycraft.cc/)              |                   ![a](assets/a.svg)![1](assets/1.svg)                   |
 |    `vibeviewer`    |       [Vibeviewer](https://github.com/MarveleE/Vibeviewer)       |                   ![a](assets/a.svg)![1](assets/1.svg)                   |
 |     `wiliwili`     |        [wiliwili](https://xfangfang.github.io/wiliwili/)         |                   ![a](assets/a.svg)![1](assets/1.svg)                   |
 |    `yank-note`     |             [Yank-Note](https://yank-note.com/zh-CN)             | ![a](assets/a.svg)![1](assets/1.svg)![2](assets/2.svg)![3](assets/3.svg) |


### PR DESCRIPTION
Closes #1174

Adds a new cask for Tiny RDM, including arm64/intel macOS artifacts, sha256 values from the v1.2.7 release assets, README listing, livecheck, and zap entries.
