### PR TITLE
ci: fix stale download lock in tap-syntax

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -35,6 +35,9 @@ jobs:
           core: false
           cask: false
 
+      - name: Clean stale download locks
+        run: rm -f /home/linuxbrew/.cache/Homebrew/downloads/*.incomplete
+
       - run: brew test-bot --only-tap-syntax
 
   bump-casks:


### PR DESCRIPTION
## 问题

CI `tap-syntax` job 间歇性失败，原因是 `brew test-bot` 安装 `actionlint` 时撞上 GHCR runner 上残留的 `.incomplete` 锁文件：

```
Error: A `brew install --formula actionlint` process has already locked
  .../sphinx-doc.rb.incomplete.
```

## 修复

在 `brew test-bot --only-tap-syntax` 前加一步清理：

```yaml
- name: Clean stale download locks
  run: rm -f /home/linuxbrew/.cache/Homebrew/downloads/*.incomplete
```

## 原因

`brew test-bot` 新版增加了 GitHub Actions 检查功能（安装 actionlint），其依赖链在前次中断时可能在共享 runner 上留下残留锁文件。
