### PR TITLE
Add Lingjing Script Tool cask

### DIFF
--- a/Casks/l/lingjing-script-tool.rb
+++ b/Casks/l/lingjing-script-tool.rb
@@ -1,0 +1,23 @@
+cask "lingjing-script-tool" do
+  arch arm: "arm64", intel: "x64"
+
+  version "0.2.8"
+  sha256 arm:   "c931f08fc821673d3a6e0a3d1d841439501809ad0f2837ecc0c08888eefa16fb",
+         intel: "d474fbfbf00959c3a851b7b0956a556d93cc708dbb23c0307bb9c4a278e6d131"
+
+  url "https://github.com/lizheyong/lingjing-script-tool-releases/releases/download/v#{version}/Lingjing-Script-Tool-#{version}-#{arch}.dmg",
+      verified: "github.com/lizheyong/lingjing-script-tool-releases/"
+  name "Lingjing Script Tool"
+  name "灵境剧本工具"
+  desc "面向创作者的 AI 剧本工作台"
+  homepage "https://github.com/lizheyong/lingjing-script-tool-releases"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on :macos
+
+  app "Lingjing Script Tool.app"
+end

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ brew help
 |     `aidea`     |                [aidea](https://ai.aicode.cc)                | ![b](assets/b.svg)![2](assets/2.svg) |
 |   `autotyper`   |     [AutoTyper](https://autoglm.zhipuai.cn/autotyper/)      | ![b](assets/b.svg)![1](assets/1.svg) |
 | `cockpit-tools` | [cockpit-tools](https://github.com/jlcodes99/cockpit-tools) | ![a](assets/a.svg)![1](assets/1.svg) |
+| `lingjing-script-tool` | [灵境剧本工具](https://github.com/lizheyong/lingjing-script-tool-releases) | ![a](assets/a.svg)![1](assets/1.svg) |
 
 ### 代理工具
 


### PR DESCRIPTION
## Summary
- Add the Lingjing Script Tool cask for macOS Apple Silicon and Intel.
- List the cask in the AI tools section of the tap README.

## Upstream
- Release: https://github.com/lizheyong/lingjing-script-tool-releases/releases/tag/v0.2.8
- Version: 0.2.8
- SHA-256 values: official GitHub Releases asset digests for the arm64 and x64 DMGs.

## Validation
- `brew style Casks/l/lingjing-script-tool.rb`
- `brew audit --new --cask lingjing-script-tool`
- `brew install --cask --dry-run brewforge/chinese/lingjing-script-tool`
- `git diff --check`