### PR TITLE
lingjing-script-tool 0.3.0

### DIFF
--- a/Casks/l/lingjing-script-tool.rb
+++ b/Casks/l/lingjing-script-tool.rb
@@ -1,9 +1,9 @@
 cask "lingjing-script-tool" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.2.8"
-  sha256 arm:   "c931f08fc821673d3a6e0a3d1d841439501809ad0f2837ecc0c08888eefa16fb",
-         intel: "d474fbfbf00959c3a851b7b0956a556d93cc708dbb23c0307bb9c4a278e6d131"
+  version "0.3.0"
+  sha256 arm:   "ab77ec08810707166cbc21815dcec984e6682316e31d1dda873b154384b78551",
+         intel: "2ea62e4ddd7f3615190b78eda7a6d57a90dcab51244546c86aaf4bf6b0cff514"
 
   url "https://github.com/lizheyong/lingjing-script-tool-releases/releases/download/v#{version}/Lingjing-Script-Tool-#{version}-#{arch}.dmg",
       verified: "github.com/lizheyong/lingjing-script-tool-releases/"


### PR DESCRIPTION
## 变更

- 将 lingjing-script-tool 从 0.2.8 更新到 0.3.0
- 更新 Apple Silicon 与 Intel DMG 的 SHA-256

## 上游发布

- https://github.com/lizheyong/lingjing-script-tool-releases/releases/tag/v0.3.0
- macOS 安装包已通过 Developer ID 签名和 Apple 公证

## 验证

- Ruby syntax: OK
- brew style: 1 file inspected, no offenses detected
- SHA-256 与发布页 SHA256SUMS.txt 一致