### PR TITLE
anymo 2.7.11

### DIFF
--- a/Casks/a/anymo.rb
+++ b/Casks/a/anymo.rb
@@ -1,0 +1,31 @@
+cask "anymo" do
+  arch arm: "arm64", intel: "x64"
+
+  version "2.7.11"
+  sha256 :no_check
+
+  url "https://anymoweb.com/app-mac-#{arch}.dmg",
+      verified: "anymoweb.com/"
+  name "Anymo"
+  desc "终身受用的抗遗忘卡片记忆笔记"
+  homepage "https://anymoweb.com/"
+
+  livecheck do
+    url "https://anymoweb.com/app_client/latest.yml"
+    regex(/version:\s*"?(\d+(?:\.\d+)+)"?/i)
+  end
+
+  depends_on macos: :catalina
+
+  app "Anymo.app"
+
+  preflight do
+    system_command "xattr",
+                   args: ["-cr", "#{staged_path}/Anymo.app"]
+  end
+
+  zap trash: [
+    "~/Library/Application Support/Anymo",
+    "~/Library/Preferences/com.memo93.anymodesktop.plist",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ brew help
 |   `autotyper`   |     [AutoTyper](https://autoglm.zhipuai.cn/autotyper/)      | ![b](assets/b.svg)![1](assets/1.svg) |
 | `cockpit-tools` | [cockpit-tools](https://github.com/jlcodes99/cockpit-tools) | ![a](assets/a.svg)![1](assets/1.svg) |
 | `lingjing-script-tool` | [灵境剧本工具](https://github.com/lizheyong/lingjing-script-tool-releases) | ![a](assets/a.svg)![1](assets/1.svg) |
+| `qoderwork-cn` | [Qoder](https://qoder.com.cn/qoderwork) | ![b](assets/b.svg)![1](assets/1.svg) |
 
 ### 代理工具
 
@@ -121,6 +122,7 @@ brew help
 
 |        桶名        |                             软件官网                             |                                   备注                                   |
 | :----------------: | :--------------------------------------------------------------: | :----------------------------------------------------------------------: |
+|      `anymo`       |                   [Anymo](https://anymoweb.com/)                 |          ![b](assets/b.svg)![1](assets/1.svg)![3](assets/3.svg)          |
 |    `bilitools`     |            [BiliTools](https://btjawa.top/bilitools/)            |                   ![a](assets/b.svg)![1](assets/1.svg)                   |
 |    `cajviewer`     |      [CAJViewer](https://CAJViewer.cnki.net/download.html)       |                   ![b](assets/b.svg)![1](assets/1.svg)                   |
 | `chaoxing-cxstudy` |               [学习通](https://app.chaoxing.com/)                |                   ![b](assets/b.svg)![1](assets/1.svg)                   |
@@ -148,6 +150,7 @@ brew help
 |  `project-graph`   |    [Project Graph](https://github.com/graphif/project-graph)     |                   ![a](assets/a.svg)![1](assets/1.svg)                   |
 |      `presto`      |          [Presto](https://github.com/Presto-io/Presto)           |                   ![a](assets/a.svg)![1](assets/1.svg)                   |
 | `quarkclouddrive`  |                 [夸克网盘](https://pan.quark.cn)                 |                   ![b](assets/b.svg)![1](assets/1.svg)                   |
+|    `retain-pdf`    |        [retain-pdf](https://github.com/wxyhgk/retain-pdf)        |                   ![a](assets/a.svg)![1](assets/1.svg)                   |
 |  `splayer-imsyy`   |           [SPlayer](https://github.com/imsyy/SPlayer)            |                   ![a](assets/a.svg)![1](assets/1.svg)                   |
 |   `tts-vue-next`   |       [TTS-Vue-Next](https://tts-doc.loker.vip/home.html)        |                   ![a](assets/a.svg)![1](assets/1.svg)                   |
 |     `tiny-rdm`     |             [Tiny RDM](https://redis.tinycraft.cc/)              |                   ![a](assets/a.svg)![1](assets/1.svg)                   |
@@ -205,6 +208,7 @@ brew help
 |    桶名     |              软件官网              |        问题        |
 | :---------: | :--------------------------------: | :----------------: |
 | `capcut-cn` |  [剪映中文版](https://capcut.cn/)  |   未找到版本信息   |
+| `lceda-pro` | [嘉立创 EDA 专业版](https://lceda.cn/) |      需要登录      |
 |  `landrop`  |  [LANDrop](https://landrop.app/)   | 嵌套标签，难以选择 |
 | `linkease`  | [易有云](https://app.linkease.com) | 多个结果，无法选中 |
 


### PR DESCRIPTION
Closes #654

- 新增 anymo cask（终身受用的抗遗忘卡片记忆笔记）
- 双架构（arm64 / x64），下载 URL 固定路径，采用 `sha256 :no_check`
- livecheck 走 electron-updater 的 `app_client/latest.yml`
- app 有签名但未公证，preflight 中 `xattr -cr` 处理 Gatekeeper
- README 补充遗漏条目：qoderwork-cn、retain-pdf、lceda-pro（移入揭榜区，原因：需要登录）

```
brew style --fix: PASS
brew audit --strict: PASS
brew livecheck: PASS (2.7.11 ==> 2.7.11)
```