### PR TITLE
happ 4.1.1

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,7 +45,7 @@ jobs:
           [ -n "$range" ] || range="origin/main...HEAD"
           casks=""
           while IFS= read -r file; do
-            casks+="$(basename "$file" .rb) "
+            casks+="brewforge/chinese/$(basename "$file" .rb) "
           done < <(git diff --name-only --diff-filter=ACMR "$range" -- 'Casks/*.rb')
           echo "Changed casks: ${casks:-none}"
           echo "casks=${casks% }" >> "$GITHUB_OUTPUT"
@@ -68,4 +68,6 @@ jobs:
         if: steps.changed.outputs.casks != ''
         run: |
           cd "$(brew --repository brewforge/chinese)"
-          brew audit --strict --online --cask ${{ steps.changed.outputs.casks }}
+          # setup-homebrew 会清空 HOMEBREW_NO_INSTALL_FROM_API；带 tap 全名可确保
+          # audit 加载本 tap 的 cask 文件，而非官方 API 数据里的同名 cask
+          HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --strict --online --cask ${{ steps.changed.outputs.casks }}

--- a/Casks/h/happ.rb
+++ b/Casks/h/happ.rb
@@ -18,8 +18,8 @@ cask "happ" do
 
   zap trash: [
     "~/Library/Application Support/Happ",
-    "~/Library/Caches/Happ",
     "~/Library/Caches/com.happ.www",
+    "~/Library/Caches/Happ",
     "~/Library/Preferences/com.happ.plist",
     "~/Library/Preferences/com.happ.www.plist",
     "~/Library/Saved Application State/com.happ.www.savedState",

--- a/Casks/h/happ.rb
+++ b/Casks/h/happ.rb
@@ -1,0 +1,27 @@
+cask "happ" do
+  version "4.1.1"
+  sha256 "31b900f983e5a3113af59e7fb29c5d16e91e222e31fe794a3c70509619b48122"
+
+  url "https://github.com/Happ-proxy/happ-desktop/releases/download/#{version}/Happ.macOS.universal.dmg"
+  name "Happ"
+  desc "Proxy Utility"
+  homepage "https://www.happ.su/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :ventura
+
+  app "Happ.app"
+
+  zap trash: [
+    "~/Library/Application Support/Happ",
+    "~/Library/Caches/Happ",
+    "~/Library/Caches/com.happ.www",
+    "~/Library/Preferences/com.happ.plist",
+    "~/Library/Preferences/com.happ.www.plist",
+    "~/Library/Saved Application State/com.happ.www.savedState",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ brew help
 | `clash-nyanpasu`  |          [Clash-Nyanpasu](https://github.com/libnyanpasu)           | ![a](assets/a.svg)![1](assets/1.svg) |
 |     `flclash`     |           [FlClash](https://github.com/chen08209/FlClash)           | ![a](assets/a.svg)![1](assets/1.svg) |
 | `gui-for-singbox` | [GUI.for.SingBox](https://github.com/GUI-for-Cores/GUI.for.SingBox) | ![a](assets/a.svg)![1](assets/1.svg) |
+|       `happ`      |              [Happ](https://www.happ.su/)               | ![a](assets/a.svg)![1](assets/1.svg) |
 |     `sparkle`     |          [Sparkle](https://github.com/xishang0128/sparkle)          | ![a](assets/a.svg)![1](assets/1.svg) |
 |     `throne`      |           [Throne](https://github.com/throneproj/Throne)            | ![a](assets/a.svg)![1](assets/1.svg) |
 |     `v2rayn`      |              [v2rayN](https://github.com/2dust/v2rayN)              | ![a](assets/a.svg)![1](assets/1.svg) |


### PR DESCRIPTION
Closes #1092

- 新增 cask `happ` 4.1.1（universal，macOS 13+）
- livecheck: strategy :github_latest
- README 代理工具分类新增条目

- [x] brew style --fix 通过
- [x] brew audit --strict 通过
- [x] brew lc --cask 通过