### PR TITLE
ci: audit tap-qualified cask names with no-api env

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,7 +45,7 @@ jobs:
           [ -n "$range" ] || range="origin/main...HEAD"
           casks=""
           while IFS= read -r file; do
-            casks+="$(basename "$file" .rb) "
+            casks+="brewforge/chinese/$(basename "$file" .rb) "
           done < <(git diff --name-only --diff-filter=ACMR "$range" -- 'Casks/*.rb')
           echo "Changed casks: ${casks:-none}"
           echo "casks=${casks% }" >> "$GITHUB_OUTPUT"
@@ -68,4 +68,6 @@ jobs:
         if: steps.changed.outputs.casks != ''
         run: |
           cd "$(brew --repository brewforge/chinese)"
-          brew audit --strict --online --cask ${{ steps.changed.outputs.casks }}
+          # setup-homebrew 会清空 HOMEBREW_NO_INSTALL_FROM_API；带 tap 全名可确保
+          # audit 加载本 tap 的 cask 文件，而非官方 API 数据里的同名 cask
+          HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --strict --online --cask ${{ steps.changed.outputs.casks }}


### PR DESCRIPTION
## 背景

PR #1425（happ cask，已关闭）的 validate workflow 失败：`brew audit --strict --online --cask happ` 报

> Version '3.3.6' differs from '4.1.1' retrieved by livecheck.

而 tap 里的文件明明写的是 4.1.1。

## 根因

1. Workflow 顶层的 `HOMEBREW_NO_INSTALL_FROM_API=1` 会被 `setup-homebrew` action **清空**（CI 日志中 checkout/setup 步骤时值为 `1`，后续步骤变为空）
2. 于是裸名 `brew audit --cask happ` 走 API 加载器（加载器优先级 `FromAPILoader > FromTapLoader > FromNameLoader`），解析到**官方 homebrew/cask 的同名 cask**，而非本 tap 的文件
3. 当时 formulae.brew.sh 的 happ 数据尚未同步官方 8-24 的 4.1.1 提交（02:55 GMT 才更新），audit 读到旧的 3.3.6；livecheck 直接查 GitHub 得到 4.1.1 → version mismatch

本地无法复现是因为本地 API 缓存已是最新。

## 修复

- **Determine changed casks**: 生成的名字加 tap 前缀 → `brewforge/chinese/<cask>`。带全名走 `FromTapLoader` 直接读本 tap 文件，绕开官方 API 同名冲突
- **Audit 步骤**: 显式设置 `HOMEBREW_NO_INSTALL_FROM_API=1`，双保险

## 验证

- 本地以 CI 等价环境（API 模式 + tap 全名 + no-api env）复跑 style/audit/livecheck 全部通过
- 原 run [32925578104](https://github.com/Brewforge/homebrew-chinese/actions/runs/32925578104)（含此修复）Style ✓ Audit ✓