### PR TITLE
Fix deprecated Cask DSL for current Homebrew

### DIFF
--- a/Casks/a/aidea.rb
+++ b/Casks/a/aidea.rb
@@ -2,8 +2,7 @@ cask "aidea" do
   version "2.0.0"
   sha256 "b87710e26b55ae0025539b1e8bb56aad8abc436e3929dee609cc085f2ffb1c20"
 
-  url "https://github.com/mylxsw/aidea/releases/download/#{version}/aidea-#{version}-macos.dmg",
-      verified: "github.com/mylxsw/aidea/"
+  url "https://github.com/mylxsw/aidea/releases/download/#{version}/aidea-#{version}-macos.dmg"
   name "AIdea"
   desc "一款支持 GPT 以及国产大语言模型，以及 Stable Diffusion 的全能型 APP"
   homepage "https://ai.aicode.cc/"

--- a/Casks/a/anymo.rb
+++ b/Casks/a/anymo.rb
@@ -14,13 +14,12 @@ cask "anymo" do
     regex(/version:\s*"?(\d+(?:\.\d+)+)"?/i)
   end
 
-  depends_on macos: :catalina
+  depends_on :macos
 
   app "Anymo.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/Anymo.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/Anymo.app"]
   end
 
   zap trash: [

--- a/Casks/a/autotyper.rb
+++ b/Casks/a/autotyper.rb
@@ -2,8 +2,7 @@ cask "autotyper" do
   version "041006"
   sha256 "6651287fa312324a36055218e9fa55f6fb11b70ebb8ccf7b7da3d41dce8e7afd"
 
-  url "https://autoglm.aminer.cn/desktop_client/AutoTyper_#{version}.dmg",
-      verified: "autoglm.aminer.cn/"
+  url "https://autoglm.aminer.cn/desktop_client/AutoTyper_#{version}.dmg"
   name "AutoTyper"
   desc "一款智能的AI语音输入工具"
   homepage "https://autoglm.zhipuai.cn/"
@@ -17,9 +16,8 @@ cask "autotyper" do
 
   app "AutoGLM.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/AutoGLM.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/AutoGLM.app"]
   end
 
   zap trash: [

--- a/Casks/b/bilitools.rb
+++ b/Casks/b/bilitools.rb
@@ -5,8 +5,7 @@ cask "bilitools" do
   sha256 arm:   "8a778b7b7b09452c56b0833994255903f784b8d2f5b407cf04b14ac9ddaa0288",
          intel: "f5500b45e404b2b8d790135051fe40a90fe78d32095e04508372dfb6f62fdd54"
 
-  url "https://github.com/btjawa/BiliTools/releases/download/v#{version}/BiliTools_#{version}_#{arch}.dmg",
-      verified: "github.com/btjawa/BiliTools/"
+  url "https://github.com/btjawa/BiliTools/releases/download/v#{version}/BiliTools_#{version}_#{arch}.dmg"
   name "BiliTools"
   desc "跨平台哔哩哔哩工具箱"
   homepage "https://btjawa.top/bilitools"

--- a/Casks/b/blender-cn.rb
+++ b/Casks/b/blender-cn.rb
@@ -2,8 +2,7 @@ cask "blender-cn" do
   version "5.2.1"
   sha256 "6409e21de80994db5f4c4a34486b6fd43cea21085b912f7491c53e923acb65a3"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/blender/release/Blender#{version.major_minor}/blender-#{version}-macos-arm64.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/"
+  url "https://mirrors.tuna.tsinghua.edu.cn/blender/release/Blender#{version.major_minor}/blender-#{version}-macos-arm64.dmg"
   name "Blender"
   desc "3D creation suite"
   homepage "https://www.blender.org/"
@@ -43,13 +42,13 @@ cask "blender-cn" do
   shimscript = "#{staged_path}/blender.wrapper.sh"
   binary shimscript, target: "blender"
 
-  preflight do
+  preflight_steps do
     # make __pycache__ directories writable, otherwise uninstall fails
-    FileUtils.chmod "u+w", Dir.glob("#{staged_path}/*.app/**/__pycache__")
+    set_permissions "*.app/**/__pycache__", "u+w", recursive: false
 
-    File.write shimscript, <<~EOS
+    write_file "blender.wrapper.sh", <<~EOS
       #!/bin/bash
-      '#{appdir}/Blender.app/Contents/MacOS/Blender' "$@"
+      '{{appdir}}/Blender.app/Contents/MacOS/Blender' "$@"
     EOS
   end
 

--- a/Casks/b/blender@lts-cn.rb
+++ b/Casks/b/blender@lts-cn.rb
@@ -5,8 +5,7 @@ cask "blender@lts-cn" do
   sha256 arm:   "e19e353486ebe79fd61b7b1424971c44abd8dfd20dd6dd43753e78c3e3f30704",
          intel: "7bc6d2fed3ac4c49c82959868b9f8086315573a3e4cdcee16de2dec93010a1a8"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/blender/release/Blender#{version.major_minor}/blender-#{version}-macos-#{arch}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/"
+  url "https://mirrors.tuna.tsinghua.edu.cn/blender/release/Blender#{version.major_minor}/blender-#{version}-macos-#{arch}.dmg"
   name "Blender"
   desc "Free and open-source 3D creation suite"
   homepage "https://www.blender.org/"
@@ -27,13 +26,13 @@ cask "blender@lts-cn" do
   shimscript = "#{staged_path}/blender.wrapper.sh"
   binary shimscript, target: "blender"
 
-  preflight do
+  preflight_steps do
     # make __pycache__ directories writable, otherwise uninstall fails
-    FileUtils.chmod "u+w", Dir.glob("#{staged_path}/*.app/**/__pycache__")
+    set_permissions "*.app/**/__pycache__", "u+w", recursive: false
 
-    File.write shimscript, <<~EOS
+    write_file "blender.wrapper.sh", <<~EOS
       #!/bin/bash
-      '#{appdir}/Blender.app/Contents/MacOS/Blender' "$@"
+      '{{appdir}}/Blender.app/Contents/MacOS/Blender' "$@"
     EOS
   end
 

--- a/Casks/c/cajviewer.rb
+++ b/Casks/c/cajviewer.rb
@@ -30,9 +30,8 @@ cask "cajviewer" do
 
   app "CAJViewer.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/CAJViewer.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/CAJViewer.app"]
   end
 
   zap trash: [

--- a/Casks/c/capcut-cn.rb
+++ b/Casks/c/capcut-cn.rb
@@ -2,8 +2,7 @@ cask "capcut-cn" do
   version "0_1.2.14"
   sha256 :no_check
 
-  url "https://lf3-package.vlabstatic.com/obj/faceu-packages/installer/jianying_jianyingpro_#{version}_installer.dmg",
-      verified: "lf3-package.vlabstatic.com/obj/faceu-packages/installer/"
+  url "https://lf3-package.vlabstatic.com/obj/faceu-packages/installer/jianying_jianyingpro_#{version}_installer.dmg"
   name "剪映专业版"
   desc "全能易用的桌面端剪辑软件，让创作更简单"
   homepage "https://www.capcut.cn/"

--- a/Casks/c/capcut-cn.rb
+++ b/Casks/c/capcut-cn.rb
@@ -11,7 +11,6 @@ cask "capcut-cn" do
     skip "No Infomation Available Found"
   end
 
-
   installer script: {
     executable: "jianying-installer.app/Contents/MacOS/jianying-installer",
     args:       ["-q"],

--- a/Casks/c/clash-nyanpasu.rb
+++ b/Casks/c/clash-nyanpasu.rb
@@ -19,9 +19,8 @@ cask "clash-nyanpasu" do
 
   app "Clash Nyanpasu.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/Clash Nyanpasu.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/Clash Nyanpasu.app"]
   end
 
   zap trash: [

--- a/Casks/c/clashx-meta.rb
+++ b/Casks/c/clashx-meta.rb
@@ -16,9 +16,8 @@ cask "clashx-meta" do
 
   app "ClashX Meta.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/ClashX Meta.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/ClashX Meta.app"]
   end
 
   zap trash: [

--- a/Casks/c/cockpit-tools.rb
+++ b/Casks/c/cockpit-tools.rb
@@ -19,9 +19,8 @@ cask "cockpit-tools" do
 
   app "Cockpit Tools.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/Cockpit Tools.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/Cockpit Tools.app"]
   end
 
   zap trash: [

--- a/Casks/d/dbeaver-cn.rb
+++ b/Casks/d/dbeaver-cn.rb
@@ -5,8 +5,7 @@ cask "dbeaver-cn" do
   sha256 arm:   "62a03aa88429d4eef3576550397aae75d2576a012deda0c83d4b44f5fbcd4a3f",
          intel: "43c3bd4b67c2727cafd2901c0875a964370b5c37eff5e616643ceb145989f7c1"
 
-  url "https://mirrors.ustc.edu.cn/github-release/dbeaver/dbeaver/LatestRelease/dbeaver-ce-#{version}-macos-#{arch}.dmg",
-      verified: "mirrors.ustc.edu.cn/github-release/dbeaver/dbeaver/"
+  url "https://mirrors.ustc.edu.cn/github-release/dbeaver/dbeaver/LatestRelease/dbeaver-ce-#{version}-macos-#{arch}.dmg"
   name "DBeaver Community Edition"
   desc "Universal database tool and SQL client"
   homepage "https://dbeaver.io/"

--- a/Casks/d/dehelper-cn.rb
+++ b/Casks/d/dehelper-cn.rb
@@ -18,9 +18,8 @@ cask "dehelper-cn" do
 
   app "Dehelper.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/Dehelper.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/Dehelper.app"]
   end
 
   uninstall quit: [

--- a/Casks/d/douyin-ar.rb
+++ b/Casks/d/douyin-ar.rb
@@ -2,8 +2,7 @@ cask "douyin-ar" do
   version "6.0.0"
   sha256 "6fe7f60d55919e9145366cc57c2a4e766445c98607f92d14d3d320d6fd3634ab"
 
-  url "https://lf3-static.bytednsdoc.com/obj/eden-cn/olfk_ajlmml_zlp/ljhwZthlaukjlkulzlp/Douyin_AR#{version.no_dots}/Douyin_AR_#{version}_M1.dmg",
-      verified: "lf3-static.bytednsdoc.com/"
+  url "https://lf3-static.bytednsdoc.com/obj/eden-cn/olfk_ajlmml_zlp/ljhwZthlaukjlkulzlp/Douyin_AR#{version.no_dots}/Douyin_AR_#{version}_M1.dmg"
   name "像塑"
   name "Douyin AR"
   desc "开启抖音素材创作之旅"

--- a/Casks/e/easyspider.rb
+++ b/Casks/e/easyspider.rb
@@ -2,8 +2,7 @@ cask "easyspider" do
   version "0.6.5"
   sha256 "40f40ad9040792867613ac2809052b9410048cd5a598b09d5bae08de9ed04d25"
 
-  url "https://github.com/NaiboWang/EasySpider/releases/download/v#{version}/EasySpider_#{version}_MacOS_Apple_Arm_Chip.7z",
-      verified: "github.com/NaiboWang/EasySpider/"
+  url "https://github.com/NaiboWang/EasySpider/releases/download/v#{version}/EasySpider_#{version}_MacOS_Apple_Arm_Chip.7z"
   name "EasySpider"
   desc "Visual No-Code/Code-Free Web Crawler/Spider"
   homepage "https://easyspider.net/"

--- a/Casks/e/easytier-gui.rb
+++ b/Casks/e/easytier-gui.rb
@@ -5,8 +5,7 @@ cask "easytier-gui" do
   sha256 arm:   "29358d4b565f890b872c72092aa6391636700aae229b3a6baedaf9544b1d1407",
          intel: "f1ea217767ba88cd1b084d597359fd7e74ab17acb636fa1d8bf1c5441f726036"
 
-  url "https://github.com/EasyTier/EasyTier/releases/download/v#{version}/easytier-gui_#{version}_#{arch}.dmg",
-      verified: "github.com/EasyTier/EasyTier/"
+  url "https://github.com/EasyTier/EasyTier/releases/download/v#{version}/easytier-gui_#{version}_#{arch}.dmg"
   name "EasyTier"
   desc "简单、安全、去中心化的内网穿透 VPN 组网方案"
   homepage "https://easytier.cn/"

--- a/Casks/e/enjoy.rb
+++ b/Casks/e/enjoy.rb
@@ -5,8 +5,7 @@ cask "enjoy" do
   sha256 arm:   "4cd771d9408c3acab4ae6870cacb832470ee592fc46d5ccd608de989b312db56",
          intel: "9e62cfa80a4bd12eb7b1d4a37564a704b531531414dd3df2676e26717438a98e"
 
-  url "https://github.com/xiaolai/everyone-can-use-english/releases/download/v#{version}/Enjoy-#{version}-#{arch}.dmg",
-      verified: "github.com/xiaolai/everyone-can-use-english/"
+  url "https://github.com/xiaolai/everyone-can-use-english/releases/download/v#{version}/Enjoy-#{version}-#{arch}.dmg"
   name "Enjoy"
   desc "AI 最好的助教"
   homepage "https://1000h.org/enjoy-app/"

--- a/Casks/e/esearch.rb
+++ b/Casks/e/esearch.rb
@@ -5,8 +5,7 @@ cask "esearch" do
   sha256 arm:   "762c337601a907a410efa873fbf7f0869df6a927449da29da3414490fb6908fe",
          intel: "704f71b3d7e06bc890fef5a6f6dc8c4c7fbaa2a126a02aeb891af749676c512e"
 
-  url "https://github.com/xushengfeng/eSearch/releases/download/#{version}/eSearch-#{version}-darwin-#{arch}.dmg",
-      verified: "github.com/xushengfeng/eSearch/"
+  url "https://github.com/xushengfeng/eSearch/releases/download/#{version}/eSearch-#{version}-darwin-#{arch}.dmg"
   name "eSearch"
   desc "Screenshot, OCR, Search, Translation and More"
   homepage "https://esearch-app.netlify.app/"

--- a/Casks/e/eshelper-cn.rb
+++ b/Casks/e/eshelper-cn.rb
@@ -18,9 +18,8 @@ cask "eshelper-cn" do
 
   app "Eudic_es.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/Eudic_es.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/Eudic_es.app"]
   end
 
   uninstall quit: [

--- a/Casks/f/feeluown.rb
+++ b/Casks/f/feeluown.rb
@@ -2,8 +2,7 @@ cask "feeluown" do
   version "5.1.2,15.7.7"
   sha256 "9cd776a9015f1f35d7163a9b8b236eb20bf31825c73b3bbfd7ccf7e71ff07fbf"
 
-  url "https://github.com/feeluown/FeelUOwn/releases/download/v#{version.csv.first}/FeelUOwnX-macOS#{version.csv.second}-arm64.zip",
-      verified: "github.com/feeluown/FeelUOwn/"
+  url "https://github.com/feeluown/FeelUOwn/releases/download/v#{version.csv.first}/FeelUOwnX-macOS#{version.csv.second}-arm64.zip"
   name "FeelUOwn"
   desc "一个稳定、用户友好以及高度可定制的音乐播放器"
   homepage "https://feeluown.readthedocs.io/"

--- a/Casks/f/flclash.rb
+++ b/Casks/f/flclash.rb
@@ -19,9 +19,8 @@ cask "flclash" do
 
   app "FlClash.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/FlClash.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/FlClash.app"]
   end
 
   zap trash: [

--- a/Casks/g/gimp-cn.rb
+++ b/Casks/g/gimp-cn.rb
@@ -5,8 +5,7 @@ cask "gimp-cn" do
   sha256 arm:   "294c016dca7795999129a38b462f80fac3c13cb963e6de9d04eeb5d6e519392b",
          intel: "85214a388687718d30169d88b22794d6b0a89849bcc7aa456f4afb83c1326be8"
 
-  url "https://mirrors.ustc.edu.cn/gimp/v#{version.major_minor}/macos/gimp-#{version.csv.first}-#{arch}#{"-#{version.csv.second}" if version.csv.second}.dmg",
-      verified: "mirrors.ustc.edu.cn/gimp/"
+  url "https://mirrors.ustc.edu.cn/gimp/v#{version.major_minor}/macos/gimp-#{version.csv.first}-#{arch}#{"-#{version.csv.second}" if version.csv.second}.dmg"
   name "GIMP development version"
   desc "Free and open-source image editor"
   homepage "https://gimp.org/"
@@ -32,10 +31,10 @@ cask "gimp-cn" do
   shimscript = "#{staged_path}/gimp.wrapper.sh"
   binary shimscript, target: "gimp"
 
-  preflight do
-    File.write shimscript, <<~EOS
+  preflight_steps do
+    write_file "gimp.wrapper.sh", <<~EOS
       #!/bin/sh
-      "#{appdir}/GIMP.app/Contents/MacOS/gimp" "$@"
+      "{{appdir}}/GIMP.app/Contents/MacOS/gimp" "$@"
     EOS
   end
 

--- a/Casks/i/iina-cn.rb
+++ b/Casks/i/iina-cn.rb
@@ -2,8 +2,7 @@ cask "iina-cn" do
   version "1.4.4"
   sha256 "dd0fc0bd4b37fb57a1c8d30d6e3201b3a64bafd29959fe56953964613237beb1"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/iina/IINA.v#{version}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/iina/"
+  url "https://mirrors.tuna.tsinghua.edu.cn/iina/IINA.v#{version}.dmg"
   name "IINA"
   desc "Free and open-source media player"
   homepage "https://iina.io/"

--- a/Casks/i/inkscape-cn.rb
+++ b/Casks/i/inkscape-cn.rb
@@ -5,8 +5,7 @@ cask "inkscape-cn" do
   sha256 arm:   "118e9e23190eea1265592a8b2053f5fb67e13a55b9311b2ab284df7008a896b4",
          intel: "f0b05d5195e3aa0ba9d6d6a972f1d7f57abd876532b4d6eb02ecc98c0dcdfdbf"
 
-  url "https://mirror.nju.edu.cn/inkscape/Inkscape-#{version}_#{arch}.dmg",
-      verified: "mirror.nju.edu.cn/inkscape/"
+  url "https://mirror.nju.edu.cn/inkscape/Inkscape-#{version}_#{arch}.dmg"
   name "Inkscape"
   desc "Vector graphics editor"
   homepage "https://inkscape.org/"
@@ -23,10 +22,10 @@ cask "inkscape-cn" do
   shimscript = "#{staged_path}/inkscape.wrapper.sh"
   binary shimscript, target: "inkscape"
 
-  preflight do
-    File.write shimscript, <<~EOS
+  preflight_steps do
+    write_file "inkscape.wrapper.sh", <<~EOS
       #!/bin/sh
-      exec '#{staged_path}/Inkscape.app/Contents/MacOS/inkscape' "$@"
+      exec '{{staged_path}}/Inkscape.app/Contents/MacOS/inkscape' "$@"
     EOS
   end
 

--- a/Casks/i/iqiyi.rb
+++ b/Casks/i/iqiyi.rb
@@ -2,8 +2,7 @@ cask "iqiyi" do
   version "17.8.0,20260821101500"
   sha256 :no_check
 
-  url "https://static-d.iqiyi.com/ext/common/iQIYIMedia_271.dmg",
-      verified: "static-d.iqiyi.com/ext/common/"
+  url "https://static-d.iqiyi.com/ext/common/iQIYIMedia_271.dmg"
   name "爱奇艺视频"
   desc "爱奇艺视频官方客户端"
   homepage "https://app.iqiyi.com/mac/player/index.html"

--- a/Casks/j/julia-cn.rb
+++ b/Casks/j/julia-cn.rb
@@ -6,8 +6,7 @@ cask "julia-cn" do
   sha256 arm:   "3c9c2978a4940c0c338f6b665d30c70da188e88bd03d739d5185187254967b8a",
          intel: "c3fe0d7065f891370eb8848e3d57d2e8998d1b21d6a4ce0b35d9a4d603a2abac"
 
-  url "https://mirrors.ustc.edu.cn/julia-releases/bin/mac/#{arch}/#{version.major_minor}/julia-#{version}-mac#{arch.delete_prefix("x")}.dmg",
-      verified: "mirrors.ustc.edu.cn/julia-releases/bin/mac/"
+  url "https://mirrors.ustc.edu.cn/julia-releases/bin/mac/#{arch}/#{version.major_minor}/julia-#{version}-mac#{arch.delete_prefix("x")}.dmg"
   name "Julia"
   desc "Programming language for technical computing"
   homepage "https://julialang.org/"

--- a/Casks/j/julia@lts-cn.rb
+++ b/Casks/j/julia@lts-cn.rb
@@ -5,8 +5,7 @@ cask "julia@lts-cn" do
   sha256 arm:   "7283a27f8a8c12495fbba8cbf38e5b284fecaba9d54da1e0f8d6d8cedb4f4d92",
          intel: "18c0daffdc4504116d2e29e96b0b81ad98d20c88196d48d377ccffb71ab0ca73"
 
-  url "https://mirrors.ustc.edu.cn/julia-releases/bin/mac/#{arch}/#{version.major_minor}/julia-#{version}-mac#{arch.delete_prefix("x")}.dmg",
-      verified: "mirrors.ustc.edu.cn/julia-releases/bin/mac/"
+  url "https://mirrors.ustc.edu.cn/julia-releases/bin/mac/#{arch}/#{version.major_minor}/julia-#{version}-mac#{arch.delete_prefix("x")}.dmg"
   name "Julia"
   desc "Programming language for technical computing"
   homepage "https://julialang.org/"

--- a/Casks/k/kicad-cn.rb
+++ b/Casks/k/kicad-cn.rb
@@ -2,8 +2,7 @@ cask "kicad-cn" do
   version "10.0.6"
   sha256 "ef4dcd4278c46d3efcd28c8db273d5957d68efda028f6bf79b4811fc5302dc68"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/kicad/osx/stable/kicad-unified-universal-#{version}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/kicad/"
+  url "https://mirrors.tuna.tsinghua.edu.cn/kicad/osx/stable/kicad-unified-universal-#{version}.dmg"
   name "KiCad"
   desc "Electronics design automation suite"
   homepage "https://kicad.org/"

--- a/Casks/l/lingquan.rb
+++ b/Casks/l/lingquan.rb
@@ -1,6 +1,6 @@
 cask "lingquan" do
-  arch arm: "-arm64", intel: ""
-  folder = on_arch_conditional arm: "", intel: "/x64"
+  arch arm: "-arm64"
+  folder = on_arch_conditional intel: "/x64"
 
   version "1.1.5"
   sha256 :no_check

--- a/Casks/l/lingquan.rb
+++ b/Casks/l/lingquan.rb
@@ -5,8 +5,7 @@ cask "lingquan" do
   version "1.1.5"
   sha256 :no_check
 
-  url "https://updater-1305474371.cos.ap-guangzhou.myqcloud.com/download#{folder}/%E9%9B%B6%E6%B3%89-#{version}#{arch}.dmg",
-      verified: "updater-1305474371.cos.ap-guangzhou.myqcloud.com"
+  url "https://updater-1305474371.cos.ap-guangzhou.myqcloud.com/download#{folder}/%E9%9B%B6%E6%B3%89-#{version}#{arch}.dmg"
   name "零泉"
   desc "零泉可以轻松管理「图片、视频、音频、字体、3D 以及设计类源文件」等，各种文件，让创意工作更加简单，高效"
   homepage "https://lingquan.cool/"

--- a/Casks/l/linkease.rb
+++ b/Casks/l/linkease.rb
@@ -2,8 +2,7 @@ cask "linkease" do
   version "1.7.4"
   sha256 :no_check
 
-  url "https://fw.koolcenter.com/binary/LinkEase/Client/LinkEase.dmg",
-      verified: "fw.koolcenter.com/binary/"
+  url "https://fw.koolcenter.com/binary/LinkEase/Client/LinkEase.dmg"
   name "LinkEase"
   desc "一个可以随时随地远程连接个人 文件或设备的私有存储云"
   homepage "https://main.linkease.com/"

--- a/Casks/l/lyx-cn.rb
+++ b/Casks/l/lyx-cn.rb
@@ -2,8 +2,7 @@ cask "lyx-cn" do
   version "2.5.2,6"
   sha256 "329a4f45a04f2585eac7b44722f068fe24722481dcc8521dc284c02161fb2855"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/lyx/bin/#{version.csv.first.major_minor_patch}/LyX-#{version.csv.first}+qt#{version.csv.second}-x86_64-arm64-cocoa.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/lyx/bin/"
+  url "https://mirrors.tuna.tsinghua.edu.cn/lyx/bin/#{version.csv.first.major_minor_patch}/LyX-#{version.csv.first}+qt#{version.csv.second}-x86_64-arm64-cocoa.dmg"
   name "LyX"
   desc "GUI document processor based on the LaTeX typesetting system"
   homepage "https://www.lyx.org/"

--- a/Casks/m/macoptimizer.rb
+++ b/Casks/m/macoptimizer.rb
@@ -19,9 +19,8 @@ cask "macoptimizer" do
 
   app "Mac优化大师.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/MacOptimizer-v#{version}-#{arch}.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/MacOptimizer-v#{version}-#{arch}.app"]
   end
 
   zap trash: [

--- a/Casks/m/miniforge-cn.rb
+++ b/Casks/m/miniforge-cn.rb
@@ -14,8 +14,7 @@ cask "miniforge-cn" do
     arch arm: "aarch64", intel: "x86_64"
   end
 
-  url "https://mirrors.ustc.edu.cn/github-release/conda-forge/miniforge/LatestRelease/Miniforge3-#{version}-#{os}-#{arch}.sh",
-      verified: "mirrors.ustc.edu.cn/github-release/conda-forge/miniforge/"
+  url "https://mirrors.ustc.edu.cn/github-release/conda-forge/miniforge/LatestRelease/Miniforge3-#{version}-#{os}-#{arch}.sh"
   name "miniforge"
   desc "Minimal installer for conda specific to conda-forge"
   homepage "https://github.com/conda-forge/miniforge"
@@ -40,16 +39,16 @@ cask "miniforge-cn" do
   binary "#{caskroom_path}/base/condabin/conda"
   binary "#{caskroom_path}/base/condabin/mamba"
 
-  postflight do
-    if Dir.exist? "#{HOMEBREW_TEMP}/#{token}-envs"
-      FileUtils.rm_r "#{caskroom_path}/base/envs"
-      FileUtils.mv "#{HOMEBREW_TEMP}/#{token}-envs", "#{caskroom_path}/base/envs"
+  postflight_steps do
+    if_path_exists "{{temp}}/{{token}}-envs" do
+      remove "base/envs", base: :caskroom_path, recursive: true
+      move "{{temp}}/{{token}}-envs", "base/envs", target_base: :caskroom_path
     end
   end
 
-  uninstall_preflight do
-    if Dir.exist? "#{caskroom_path}/base/envs"
-      FileUtils.mv "#{caskroom_path}/base/envs", "#{HOMEBREW_TEMP}/#{token}-envs"
+  uninstall_preflight_steps do
+    if_path_exists "{{caskroom_path}}/base/envs" do
+      move "base/envs", "{{temp}}/{{token}}-envs", source_base: :caskroom_path
     end
   end
 

--- a/Casks/m/mogan-cn.rb
+++ b/Casks/m/mogan-cn.rb
@@ -2,8 +2,7 @@ cask "mogan-cn" do
   version "2026.3.2"
   sha256 "144507514e2ae389e09da95d69647f5b9645ecf91179e50be9475e565e408e7e"
 
-  url "https://mirrors.ustc.edu.cn/github-release/XmacsLabs/mogan/LatestRelease/MoganSTEM-v#{version}-arm.dmg",
-      verified: "mirrors.ustc.edu.cn/github-release/XmacsLabs/mogan/"
+  url "https://mirrors.ustc.edu.cn/github-release/XmacsLabs/mogan/LatestRelease/MoganSTEM-v#{version}-arm.dmg"
   name "Mogan STEM"
   desc "Structured STEM suite"
   homepage "https://mogan.app/"

--- a/Casks/o/obs-cn.rb
+++ b/Casks/o/obs-cn.rb
@@ -5,8 +5,7 @@ cask "obs-cn" do
   sha256 arm:   "920d6f26703d2df6e4085bd3c1cbed30488325084136c7a6e9e37021fbd6aaf7",
          intel: "f8d8afe3dffdc86efa0698c02ff0c997866bac3e6208ddaf56d37108baacf197"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/github-release/obsproject/obs-studio/LatestRelease/OBS-Studio-#{version}-macOS-#{arch}.dmg",
-      verified: "mirrors.tuna.tsinghua.edu.cn/"
+  url "https://mirrors.tuna.tsinghua.edu.cn/github-release/obsproject/obs-studio/LatestRelease/OBS-Studio-#{version}-macOS-#{arch}.dmg"
   name "OBS"
   desc "Open-source software for live streaming and screen recording"
   homepage "https://obsproject.com/"
@@ -24,10 +23,10 @@ cask "obs-cn" do
   shimscript = "#{staged_path}/obs.wrapper.sh"
   binary shimscript, target: "obs"
 
-  preflight do
-    File.write shimscript, <<~EOS
+  preflight_steps do
+    write_file "obs.wrapper.sh", <<~EOS
       #!/bin/bash
-      exec '#{appdir}/OBS.app/Contents/MacOS/OBS' "$@"
+      exec '{{appdir}}/OBS.app/Contents/MacOS/OBS' "$@"
     EOS
   end
 

--- a/Casks/p/project-graph.rb
+++ b/Casks/p/project-graph.rb
@@ -16,10 +16,8 @@ cask "project-graph" do
 
   app "Project Graph.app"
 
-  postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-dr", "com.apple.quarantine", "#{appdir}/Project Graph.app"],
-                   sudo: false
+  postflight_steps do
+    run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{appdir}}/Project Graph.app"]
   end
 
   zap trash: [

--- a/Casks/q/qt-creator-cn.rb
+++ b/Casks/q/qt-creator-cn.rb
@@ -2,8 +2,7 @@ cask "qt-creator-cn" do
   version "20.0.1"
   sha256 "f18ebb715619f2092e1816498e34c989b75c269bfc948169f1dd76e0231b5fa0"
 
-  url "https://mirrors.ustc.edu.cn/qtproject/official_releases/qtcreator/latest/qt-creator-opensource-mac-universal-#{version}.dmg",
-      verified: "mirrors.ustc.edu.cn/"
+  url "https://mirrors.ustc.edu.cn/qtproject/official_releases/qtcreator/latest/qt-creator-opensource-mac-universal-#{version}.dmg"
   name "Qt Creator"
   desc "IDE for application development"
   homepage "https://qt.io/developers/"

--- a/Casks/r/retain-pdf.rb
+++ b/Casks/r/retain-pdf.rb
@@ -25,9 +25,8 @@ cask "retain-pdf" do
 
   app "RetainPDF.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/RetainPDF.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/RetainPDF.app"]
   end
 
   zap trash: [

--- a/Casks/s/sagemath-cn.rb
+++ b/Casks/s/sagemath-cn.rb
@@ -5,8 +5,7 @@ cask "sagemath-cn" do
   sha256 arm:   "84f78143db3fb7c251f6eea906c6efb7793d26e96a3fbdb2104c1f9bb4b1827e",
          intel: "d8424f0401df2d5efe94c6fc8d8b8aabd53034fc9a050cb442bda09cc10e12e6"
 
-  url "https://mirrors.ustc.edu.cn/github-release/3-manifolds/Sage_macOS/LatestRelease/SageMath-#{version.csv.first}_#{arch}.dmg",
-      verified: "mirrors.ustc.edu.cn/github-release/3-manifolds/Sage_macOS/LatestRelease/"
+  url "https://mirrors.ustc.edu.cn/github-release/3-manifolds/Sage_macOS/LatestRelease/SageMath-#{version.csv.first}_#{arch}.dmg"
   name "Sage"
   desc "Mathematics software system"
   homepage "https://www.sagemath.org/"

--- a/Casks/t/texstudio-cn.rb
+++ b/Casks/t/texstudio-cn.rb
@@ -5,8 +5,7 @@ cask "texstudio-cn" do
   sha256 arm:   "5ac66e53c7cfab83621e50db3287edc7f977b2e5259806949a3915090f1898b1",
          intel: "13ef12b15c44d3cd44b58a24a5ba8ef1b5dd1304d7b67e2a0e8ba3ec0868db07"
 
-  url "https://mirrors.tuna.tsinghua.edu.cn/github-release/texstudio-org/texstudio/LatestRelease/texstudio-#{version}-osx#{arch}.zip",
-      verified: "mirrors.tuna.tsinghua.edu.cn/github-release/texstudio-org/"
+  url "https://mirrors.tuna.tsinghua.edu.cn/github-release/texstudio-org/texstudio/LatestRelease/texstudio-#{version}-osx#{arch}.zip"
   name "TeXstudio"
   desc "LaTeX editor"
   homepage "https://github.com/texstudio-org/texstudio/"

--- a/Casks/t/ting-de.rb
+++ b/Casks/t/ting-de.rb
@@ -3,7 +3,6 @@ cask "ting-de" do
   sha256 "0f391df7d065087f5a12943f3b7f6ff3a8d675f467ff2a8c2294a0f60f581f30"
 
   url "https://static.frdic.com/pkg/ting_de/ting_de.dmg?v=#{version}",
-      verified:   "static.frdic.com/",
       user_agent: :fake
   name "每日德语听力"
   desc "精听细读，更好学德语"
@@ -18,9 +17,8 @@ cask "ting-de" do
 
   app "每日德语听力.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/每日德语听力.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/每日德语听力.app"]
   end
 
   zap trash: [

--- a/Casks/t/ting-en.rb
+++ b/Casks/t/ting-en.rb
@@ -3,7 +3,6 @@ cask "ting-en" do
   sha256 "e4c2b5f99afb9560b0d8fdb2f6d0e3bf75967c0b7c8d26105746d017753d31d5"
 
   url "https://static.frdic.com/pkg/ting_en/ting_en.dmg?v=#{version}",
-      verified:   "static.frdic.com/",
       user_agent: :fake
   name "每日英语听力"
   desc "精听细读，更好学英语"
@@ -18,9 +17,8 @@ cask "ting-en" do
 
   app "每日英语听力.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/每日英语听力.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/每日英语听力.app"]
   end
 
   zap trash: [

--- a/Casks/t/ting-es.rb
+++ b/Casks/t/ting-es.rb
@@ -3,7 +3,6 @@ cask "ting-es" do
   sha256 "946bfbb335b831c98eecbd89e1dcffc3291eb0fcc9532985c5b378648ed48985"
 
   url "https://static.frdic.com/pkg/ting_es/ting_es.dmg?v=#{version}",
-      verified:   "static.frdic.com/",
       user_agent: :fake
   name "每日西语听力"
   desc "精听细读，更好学西语"
@@ -18,9 +17,8 @@ cask "ting-es" do
 
   app "每日西语听力.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/每日西语听力.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/每日西语听力.app"]
   end
 
   zap trash: [

--- a/Casks/t/ting-fr.rb
+++ b/Casks/t/ting-fr.rb
@@ -3,7 +3,6 @@ cask "ting-fr" do
   sha256 "4e5e7e809494a3141435897f6f4ba8052f682453a4426305837808eeecaa1802"
 
   url "https://static.frdic.com/pkg/ting_fr/ting_fr.dmg?v=#{version}",
-      verified:   "static.frdic.com/",
       user_agent: :fake
   name "每日法语听力"
   desc "精听细读，更好学法语"
@@ -18,9 +17,8 @@ cask "ting-fr" do
 
   app "每日法语听力.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/每日法语听力.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/每日法语听力.app"]
   end
 
   zap trash: [

--- a/Casks/t/tts-vue-next.rb
+++ b/Casks/t/tts-vue-next.rb
@@ -2,8 +2,7 @@ cask "tts-vue-next" do
   version "0.1.0"
   sha256 "e730a0521b552cfe34aac31ca20f9c55e1d022332650357e2da5d6899c07c83a"
 
-  url "https://github.com/LokerL/tts-vue-next/releases/download/v#{version}/tts-vue-next_#{version}_aarch64.dmg",
-      verified: "github.com/LokerL/tts-vue-next/"
+  url "https://github.com/LokerL/tts-vue-next/releases/download/v#{version}/tts-vue-next_#{version}_aarch64.dmg"
   name "tts-vue-next"
   desc "微软语音合成工具"
   homepage "https://tts-doc.loker.vip/home.html"
@@ -18,9 +17,8 @@ cask "tts-vue-next" do
 
   app "tts-vue-next.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/tts-vue-next.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/tts-vue-next.app"]
   end
 
   zap trash: [

--- a/Casks/v/v2rayn.rb
+++ b/Casks/v/v2rayn.rb
@@ -19,9 +19,8 @@ cask "v2rayn" do
 
   app "v2rayN.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/v2rayN.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/v2rayN.app"]
   end
 
   zap trash: [

--- a/Casks/v/v2rayxs.rb
+++ b/Casks/v/v2rayxs.rb
@@ -19,9 +19,8 @@ cask "v2rayxs" do
 
   app "V2RayXS.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/V2RayXS.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/V2RayXS.app"]
   end
 
   zap trash: [

--- a/Casks/v/vlc-cn.rb
+++ b/Casks/v/vlc-cn.rb
@@ -5,8 +5,7 @@ cask "vlc-cn" do
   sha256 arm:   "fc6fac08d87f538517d44aca0c5e7a244b67c8c4cb589bf478363a7315fd5e0d",
          intel: "ec01530ce69d849dd057fba8876e68ac39bf279dc28de4e9c04e4aec11fc98db"
 
-  url "https://mirrors.ustc.edu.cn/videolan-ftp/vlc/last/macosx/vlc-#{version}-#{arch}.dmg",
-      verified: "mirrors.ustc.edu.cn/videolan-ftp/vlc/"
+  url "https://mirrors.ustc.edu.cn/videolan-ftp/vlc/last/macosx/vlc-#{version}-#{arch}.dmg"
   name "VLC media player"
   desc "Multimedia player"
   homepage "https://videolan.org/vlc/"
@@ -24,10 +23,10 @@ cask "vlc-cn" do
   shimscript = "#{staged_path}/vlc.wrapper.sh"
   binary shimscript, target: "vlc"
 
-  preflight do
-    File.write shimscript, <<~EOS
+  preflight_steps do
+    write_file "vlc.wrapper.sh", <<~EOS
       #!/bin/sh
-      exec '#{appdir}/VLC.app/Contents/MacOS/VLC' "$@"
+      exec '{{appdir}}/VLC.app/Contents/MacOS/VLC' "$@"
     EOS
   end
 

--- a/Casks/w/wiliwili.rb
+++ b/Casks/w/wiliwili.rb
@@ -5,8 +5,7 @@ cask "wiliwili" do
   sha256 arm:   "5399c68594bbd2a5b9987b49fb266cf0d2b298dcabc3666a66f272c94fdca964",
          intel: "79813a05d667eefe847bcb1cc544f110d5776a6f021f47170a4ec142ebb04c74"
 
-  url "https://github.com/xfangfang/wiliwili/releases/download/v#{version}/wiliwili-macOS-#{arch}.dmg",
-      verified: "github.com/xfangfang/wiliwili/"
+  url "https://github.com/xfangfang/wiliwili/releases/download/v#{version}/wiliwili-macOS-#{arch}.dmg"
   name "wiliwili"
   desc "一个专为手柄用户设计的第三方 B 站 客户端"
   homepage "https://xfangfang.github.io/wiliwili/"

--- a/Casks/y/yank-note.rb
+++ b/Casks/y/yank-note.rb
@@ -5,8 +5,7 @@ cask "yank-note" do
   sha256 arm:   "696011133d6d11b9d359035f918d9122e2de06cc840e9e5fe6c14436a524557d",
          intel: "fdbdd6562e9ed006828d68e61e4d1535842486cc8d95b5ea884c8c887dafca05"
 
-  url "https://github.com/purocean/yn/releases/download/v#{version}/Yank-Note-mac-#{arch}-#{version}.dmg",
-      verified: "github.com/purocean/yn/"
+  url "https://github.com/purocean/yn/releases/download/v#{version}/Yank-Note-mac-#{arch}-#{version}.dmg"
   name "Yank Note"
   desc "高可扩展性 Markdown 笔记软件"
   homepage "https://yank-note.com/zh-CN"

--- a/deprecated/copybook.rb
+++ b/deprecated/copybook.rb
@@ -30,9 +30,8 @@ cask "copybook" do
 
   app "字帖生成器.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/字帖生成器.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/字帖生成器.app"]
   end
 
   zap trash: [


### PR DESCRIPTION
## Summary

- Remove all deprecated `verified:` URL parameters found across the tap, preserving each mirror or upstream URL.
- Migrate every legacy `preflight`, `postflight`, and `uninstall_preflight` block found by the full-tap scan to the current install-steps DSL, including xattr cleanup, wrapper generation, Blender permissions, and Miniforge environment preservation.
- Replace Anymo's disabled `depends_on macos: :catalina` with the supported macOS-only dependency. Catalina is disabled in current Homebrew, and Anymo's current release metadata provides no newer macOS minimum requirement.
- Preserve versions, checksums, URLs, architecture selectors, livechecks, artifacts, uninstall behavior, and zap scopes.

## Validation

- `brew readall brewforge/chinese --no-simulate`
- `brew style` on all 51 modified Ruby files (only pre-existing unrelated style offenses remain in capcut-cn, lingquan, and deprecated/copybook sigils)
- `brew audit --cask --strict` on all modified casks
- `brew outdated` completes without the Anymo Catalina dependency error
- `brew livecheck --cask brewforge/chinese/anymo` and related casks
- `git diff --check`
