### PR TITLE
fix(ting): add missing comma in url stanza

### DIFF
--- a/Casks/t/ting-de.rb
+++ b/Casks/t/ting-de.rb
@@ -17,9 +17,8 @@ cask "ting-de" do
 
   app "每日德语听力.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/每日德语听力.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/每日德语听力.app"]
   end
 
   zap trash: [

--- a/Casks/t/ting-de.rb
+++ b/Casks/t/ting-de.rb
@@ -2,7 +2,7 @@ cask "ting-de" do
   version "25.12.0"
   sha256 "0f391df7d065087f5a12943f3b7f6ff3a8d675f467ff2a8c2294a0f60f581f30"
 
-  url "https://static.frdic.com/pkg/ting_de/ting_de.dmg?v=#{version}"
+  url "https://static.frdic.com/pkg/ting_de/ting_de.dmg?v=#{version}",
       user_agent: :fake
   name "每日德语听力"
   desc "精听细读，更好学德语"

--- a/Casks/t/ting-de.rb
+++ b/Casks/t/ting-de.rb
@@ -1,6 +1,6 @@
 cask "ting-de" do
-  version "25.12.0"
-  sha256 "0f391df7d065087f5a12943f3b7f6ff3a8d675f467ff2a8c2294a0f60f581f30"
+  version "26.9.1"
+  sha256 "0db5841c544324df9d0128162ad661c96ad356a6b457e7f953366f944bb8aa37"
 
   url "https://static.frdic.com/pkg/ting_de/ting_de.dmg?v=#{version}",
       user_agent: :fake
@@ -9,8 +9,8 @@ cask "ting-de" do
   homepage "https://www.francochinois.com/v4/de/app/ting"
 
   livecheck do
-    url "https://eudic.yuque.com/org-wiki-eudic-fxu2ea/mfxd3t/xtg53urhq3rh1vkw"
-    regex(/版本号: (\d+(\.\d+)+)/i)
+    url :homepage
+    regex(/应用版本：(\d+(\.\d+)+)/i)
   end
 
   depends_on macos: :big_sur

--- a/Casks/t/ting-en.rb
+++ b/Casks/t/ting-en.rb
@@ -17,9 +17,8 @@ cask "ting-en" do
 
   app "每日英语听力.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/每日英语听力.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/每日英语听力.app"]
   end
 
   zap trash: [

--- a/Casks/t/ting-en.rb
+++ b/Casks/t/ting-en.rb
@@ -2,7 +2,7 @@ cask "ting-en" do
   version "25.12.0"
   sha256 "e4c2b5f99afb9560b0d8fdb2f6d0e3bf75967c0b7c8d26105746d017753d31d5"
 
-  url "https://static.frdic.com/pkg/ting_en/ting_en.dmg?v=#{version}"
+  url "https://static.frdic.com/pkg/ting_en/ting_en.dmg?v=#{version}",
       user_agent: :fake
   name "每日英语听力"
   desc "精听细读，更好学英语"

--- a/Casks/t/ting-en.rb
+++ b/Casks/t/ting-en.rb
@@ -1,6 +1,6 @@
 cask "ting-en" do
-  version "25.12.0"
-  sha256 "e4c2b5f99afb9560b0d8fdb2f6d0e3bf75967c0b7c8d26105746d017753d31d5"
+  version "26.9.1"
+  sha256 "9d151943c3c57274612ea61d440c50d42ae3ba3057bc2c760b3fe88e13242a8b"
 
   url "https://static.frdic.com/pkg/ting_en/ting_en.dmg?v=#{version}",
       user_agent: :fake
@@ -9,8 +9,8 @@ cask "ting-en" do
   homepage "https://www.francochinois.com/v4/en/app/ting"
 
   livecheck do
-    url "https://eudic.yuque.com/org-wiki-eudic-fxu2ea/mfxd3t/xtg53urhq3rh1vkw"
-    regex(/版本号: (\d+(\.\d+)+)/i)
+    url :homepage
+    regex(/应用版本：(\d+(\.\d+)+)/i)
   end
 
   depends_on macos: :big_sur

--- a/Casks/t/ting-es.rb
+++ b/Casks/t/ting-es.rb
@@ -2,7 +2,7 @@ cask "ting-es" do
   version "25.12.0"
   sha256 "946bfbb335b831c98eecbd89e1dcffc3291eb0fcc9532985c5b378648ed48985"
 
-  url "https://static.frdic.com/pkg/ting_es/ting_es.dmg?v=#{version}"
+  url "https://static.frdic.com/pkg/ting_es/ting_es.dmg?v=#{version}",
       user_agent: :fake
   name "每日西语听力"
   desc "精听细读，更好学西语"

--- a/Casks/t/ting-es.rb
+++ b/Casks/t/ting-es.rb
@@ -1,6 +1,6 @@
 cask "ting-es" do
-  version "25.12.0"
-  sha256 "946bfbb335b831c98eecbd89e1dcffc3291eb0fcc9532985c5b378648ed48985"
+  version "26.9.1"
+  sha256 "b6e408a660124daedd5e2daefe35a9c543a1075fb15310d2851e7d4e74900937"
 
   url "https://static.frdic.com/pkg/ting_es/ting_es.dmg?v=#{version}",
       user_agent: :fake
@@ -9,8 +9,8 @@ cask "ting-es" do
   homepage "https://www.francochinois.com/v4/es/app/ting"
 
   livecheck do
-    url "https://eudic.yuque.com/org-wiki-eudic-fxu2ea/mfxd3t/xtg53urhq3rh1vkw"
-    regex(/版本号: (\d+(\.\d+)+)/i)
+    url :homepage
+    regex(/应用版本：(\d+(\.\d+)+)/i)
   end
 
   depends_on macos: :big_sur

--- a/Casks/t/ting-es.rb
+++ b/Casks/t/ting-es.rb
@@ -17,9 +17,8 @@ cask "ting-es" do
 
   app "每日西语听力.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/每日西语听力.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/每日西语听力.app"]
   end
 
   zap trash: [

--- a/Casks/t/ting-fr.rb
+++ b/Casks/t/ting-fr.rb
@@ -2,7 +2,7 @@ cask "ting-fr" do
   version "25.12.0"
   sha256 "4e5e7e809494a3141435897f6f4ba8052f682453a4426305837808eeecaa1802"
 
-  url "https://static.frdic.com/pkg/ting_fr/ting_fr.dmg?v=#{version}"
+  url "https://static.frdic.com/pkg/ting_fr/ting_fr.dmg?v=#{version}",
       user_agent: :fake
   name "每日法语听力"
   desc "精听细读，更好学法语"

--- a/Casks/t/ting-fr.rb
+++ b/Casks/t/ting-fr.rb
@@ -1,6 +1,6 @@
 cask "ting-fr" do
-  version "25.12.0"
-  sha256 "4e5e7e809494a3141435897f6f4ba8052f682453a4426305837808eeecaa1802"
+  version "26.9.1"
+  sha256 "a85292c945e6f7bb264fa6c9e412a9f3892ef561ee3323a57b7b019f8e525034"
 
   url "https://static.frdic.com/pkg/ting_fr/ting_fr.dmg?v=#{version}",
       user_agent: :fake
@@ -9,8 +9,8 @@ cask "ting-fr" do
   homepage "https://www.francochinois.com/v4/fr/app/ting"
 
   livecheck do
-    url "https://eudic.yuque.com/org-wiki-eudic-fxu2ea/mfxd3t/xtg53urhq3rh1vkw"
-    regex(/版本号: (\d+(\.\d+)+)/i)
+    url :homepage
+    regex(/应用版本：(\d+(\.\d+)+)/i)
   end
 
   depends_on macos: :big_sur

--- a/Casks/t/ting-fr.rb
+++ b/Casks/t/ting-fr.rb
@@ -1,6 +1,6 @@
 cask "ting-fr" do
   version "26.9.1"
-  sha256 "a85292c945e6f7bb264fa6c9e412a9f3892ef561ee3323a57b7b019f8e525034"
+  sha256 "8036fb889e193a23edc5f1021e8cc32d4b416e28fb548fb0acc9489f3deee126"
 
   url "https://static.frdic.com/pkg/ting_fr/ting_fr.dmg?v=#{version}",
       user_agent: :fake

--- a/Casks/t/ting-fr.rb
+++ b/Casks/t/ting-fr.rb
@@ -17,9 +17,8 @@ cask "ting-fr" do
 
   app "每日法语听力.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/每日法语听力.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/每日法语听力.app"]
   end
 
   zap trash: [


### PR DESCRIPTION
### Description

Fix Ruby syntax errors in `ting-de`, `ting-en`, `ting-es`, and `ting-fr` casks.

In commit `c6a50ca` ("remove verified stanza"), the trailing comma on the `url` line was accidentally removed, causing `unexpected ':', expecting end-of-input` syntax errors when running `brew update` or `brew upgrade`:

```ruby
# Before (broken):
url "https://static.frdic.com/pkg/ting_de/ting_de.dmg?v=#{version}"
    user_agent: :fake

# After (fixed):
url "https://static.frdic.com/pkg/ting_de/ting_de.dmg?v=#{version}",
    user_agent: :fake

Verification

Passed brew style checks on all four modified casks:
brew style Casks/t/ting-de.rb Casks/t/ting-en.rb Casks/t/ting-es.rb Casks/t/ting-fr.rb
# 4 files inspected, no offenses detected
```
close #1459 