### PR TITLE
chore: migrate legacy flight blocks to canonical install steps DSL

### DIFF
--- a/Casks/a/autotyper.rb
+++ b/Casks/a/autotyper.rb
@@ -16,9 +16,8 @@ cask "autotyper" do
 
   app "AutoGLM.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/AutoGLM.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/AutoGLM.app"]
   end
 
   zap trash: [

--- a/Casks/b/blender-cn.rb
+++ b/Casks/b/blender-cn.rb
@@ -38,18 +38,11 @@ cask "blender-cn" do
   depends_on macos: :big_sur
 
   app "Blender.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/blender.wrapper.sh"
-  binary shimscript, target: "blender"
+  command_wrapper "blender",
+                  executable: "#{appdir}/Blender.app/Contents/MacOS/Blender"
 
-  preflight do
-    # make __pycache__ directories writable, otherwise uninstall fails
-    FileUtils.chmod "u+w", Dir.glob("#{staged_path}/*.app/**/__pycache__")
-
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      '#{appdir}/Blender.app/Contents/MacOS/Blender' "$@"
-    EOS
+  preflight_steps do
+    set_permissions "*.app/**/__pycache__", "u+w", recursive: false
   end
 
   zap trash: [

--- a/Casks/b/blender@lts-cn.rb
+++ b/Casks/b/blender@lts-cn.rb
@@ -22,18 +22,11 @@ cask "blender@lts-cn" do
   depends_on macos: :big_sur
 
   app "Blender.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/blender.wrapper.sh"
-  binary shimscript, target: "blender"
+  command_wrapper "blender",
+                  executable: "#{appdir}/Blender.app/Contents/MacOS/Blender"
 
-  preflight do
-    # make __pycache__ directories writable, otherwise uninstall fails
-    FileUtils.chmod "u+w", Dir.glob("#{staged_path}/*.app/**/__pycache__")
-
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      '#{appdir}/Blender.app/Contents/MacOS/Blender' "$@"
-    EOS
+  preflight_steps do
+    set_permissions "*.app/**/__pycache__", "u+w", recursive: false
   end
 
   zap trash: [

--- a/Casks/c/cajviewer.rb
+++ b/Casks/c/cajviewer.rb
@@ -30,9 +30,8 @@ cask "cajviewer" do
 
   app "CAJViewer.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/CAJViewer.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/CAJViewer.app"]
   end
 
   zap trash: [

--- a/Casks/c/clash-nyanpasu.rb
+++ b/Casks/c/clash-nyanpasu.rb
@@ -19,9 +19,8 @@ cask "clash-nyanpasu" do
 
   app "Clash Nyanpasu.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/Clash Nyanpasu.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/Clash Nyanpasu.app"]
   end
 
   zap trash: [

--- a/Casks/c/clashx-meta.rb
+++ b/Casks/c/clashx-meta.rb
@@ -16,9 +16,8 @@ cask "clashx-meta" do
 
   app "ClashX Meta.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/ClashX Meta.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/ClashX Meta.app"]
   end
 
   zap trash: [

--- a/Casks/c/cockpit-tools.rb
+++ b/Casks/c/cockpit-tools.rb
@@ -19,9 +19,8 @@ cask "cockpit-tools" do
 
   app "Cockpit Tools.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/Cockpit Tools.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/Cockpit Tools.app"]
   end
 
   zap trash: [

--- a/Casks/d/dehelper-cn.rb
+++ b/Casks/d/dehelper-cn.rb
@@ -18,9 +18,8 @@ cask "dehelper-cn" do
 
   app "Dehelper.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/Dehelper.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/Dehelper.app"]
   end
 
   uninstall quit: [

--- a/Casks/e/eshelper-cn.rb
+++ b/Casks/e/eshelper-cn.rb
@@ -18,9 +18,8 @@ cask "eshelper-cn" do
 
   app "Eudic_es.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/Eudic_es.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/Eudic_es.app"]
   end
 
   uninstall quit: [

--- a/Casks/f/flclash.rb
+++ b/Casks/f/flclash.rb
@@ -19,9 +19,8 @@ cask "flclash" do
 
   app "FlClash.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/FlClash.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/FlClash.app"]
   end
 
   zap trash: [

--- a/Casks/g/gimp-cn.rb
+++ b/Casks/g/gimp-cn.rb
@@ -28,15 +28,7 @@ cask "gimp-cn" do
   depends_on macos: :big_sur
 
   app "GIMP.app"
-  shimscript = "#{staged_path}/gimp.wrapper.sh"
-  binary shimscript, target: "gimp"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      "#{appdir}/GIMP.app/Contents/MacOS/gimp" "$@"
-    EOS
-  end
+  command_wrapper "gimp", executable: "#{appdir}/GIMP.app/Contents/MacOS/gimp"
 
   zap trash: [
     "~/Library/Application Support/Gimp",

--- a/Casks/i/inkscape-cn.rb
+++ b/Casks/i/inkscape-cn.rb
@@ -18,16 +18,7 @@ cask "inkscape-cn" do
   depends_on :macos
 
   app "Inkscape.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/inkscape.wrapper.sh"
-  binary shimscript, target: "inkscape"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{staged_path}/Inkscape.app/Contents/MacOS/inkscape' "$@"
-    EOS
-  end
+  command_wrapper "inkscape", executable: "#{appdir}/Inkscape.app/Contents/MacOS/inkscape"
 
   zap trash: [
     "~/.config/inkscape",

--- a/Casks/m/macoptimizer.rb
+++ b/Casks/m/macoptimizer.rb
@@ -19,9 +19,8 @@ cask "macoptimizer" do
 
   app "Mac优化大师.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/MacOptimizer-v#{version}-#{arch}.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/MacOptimizer-v#{version}-#{arch}.app"]
   end
 
   zap trash: [

--- a/Casks/m/miniforge-cn.rb
+++ b/Casks/m/miniforge-cn.rb
@@ -39,16 +39,16 @@ cask "miniforge-cn" do
   binary "#{caskroom_path}/base/condabin/conda"
   binary "#{caskroom_path}/base/condabin/mamba"
 
-  postflight do
-    if Dir.exist? "#{HOMEBREW_TEMP}/#{token}-envs"
-      FileUtils.rm_r "#{caskroom_path}/base/envs"
-      FileUtils.mv "#{HOMEBREW_TEMP}/#{token}-envs", "#{caskroom_path}/base/envs"
+  postflight_steps do
+    if_path_exists "{{temp}}/{{token}}-envs" do
+      remove "base/envs", base: :caskroom_path, recursive: true
+      move "{{temp}}/{{token}}-envs", "base/envs", target_base: :caskroom_path
     end
   end
 
-  uninstall_preflight do
-    if Dir.exist? "#{caskroom_path}/base/envs"
-      FileUtils.mv "#{caskroom_path}/base/envs", "#{HOMEBREW_TEMP}/#{token}-envs"
+  uninstall_preflight_steps do
+    if_path_exists "{{caskroom_path}}/base/envs" do
+      move "base/envs", "{{temp}}/{{token}}-envs", source_base: :caskroom_path
     end
   end
 

--- a/Casks/o/obs-cn.rb
+++ b/Casks/o/obs-cn.rb
@@ -19,16 +19,8 @@ cask "obs-cn" do
   depends_on macos: :ventura
 
   app "OBS.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/obs.wrapper.sh"
-  binary shimscript, target: "obs"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/bash
-      exec '#{appdir}/OBS.app/Contents/MacOS/OBS' "$@"
-    EOS
-  end
+  command_wrapper "obs",
+                  executable: "#{appdir}/OBS.app/Contents/MacOS/OBS"
 
   uninstall delete: "/Library/CoreMediaIO/Plug-Ins/DAL/obs-mac-virtualcam.plugin"
 

--- a/Casks/p/project-graph.rb
+++ b/Casks/p/project-graph.rb
@@ -16,10 +16,8 @@ cask "project-graph" do
 
   app "Project Graph.app"
 
-  postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-dr", "com.apple.quarantine", "#{appdir}/Project Graph.app"],
-                   sudo: false
+  postflight_steps do
+    run "xattr", args: ["-dr", "com.apple.quarantine", "{{appdir}}/Project Graph.app"]
   end
 
   zap trash: [

--- a/Casks/r/retain-pdf.rb
+++ b/Casks/r/retain-pdf.rb
@@ -25,9 +25,8 @@ cask "retain-pdf" do
 
   app "RetainPDF.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/RetainPDF.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/RetainPDF.app"]
   end
 
   zap trash: [

--- a/Casks/t/tts-vue-next.rb
+++ b/Casks/t/tts-vue-next.rb
@@ -17,9 +17,8 @@ cask "tts-vue-next" do
 
   app "tts-vue-next.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/tts-vue-next.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/tts-vue-next.app"]
   end
 
   zap trash: [

--- a/Casks/v/v2rayn.rb
+++ b/Casks/v/v2rayn.rb
@@ -19,9 +19,8 @@ cask "v2rayn" do
 
   app "v2rayN.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/v2rayN.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/v2rayN.app"]
   end
 
   zap trash: [

--- a/Casks/v/v2rayxs.rb
+++ b/Casks/v/v2rayxs.rb
@@ -19,9 +19,8 @@ cask "v2rayxs" do
 
   app "V2RayXS.app"
 
-  preflight do
-    system_command "xattr",
-                   args: ["-cr", "#{staged_path}/V2RayXS.app"]
+  preflight_steps do
+    run "xattr", args: ["-cr", "{{staged_path}}/V2RayXS.app"]
   end
 
   zap trash: [

--- a/Casks/v/vlc-cn.rb
+++ b/Casks/v/vlc-cn.rb
@@ -19,16 +19,8 @@ cask "vlc-cn" do
   depends_on :macos
 
   app "VLC.app"
-  # shim script (https://github.com/Homebrew/homebrew-cask/issues/18809)
-  shimscript = "#{staged_path}/vlc.wrapper.sh"
-  binary shimscript, target: "vlc"
-
-  preflight do
-    File.write shimscript, <<~EOS
-      #!/bin/sh
-      exec '#{appdir}/VLC.app/Contents/MacOS/VLC' "$@"
-    EOS
-  end
+  command_wrapper "vlc",
+                  executable: "#{appdir}/VLC.app/Contents/MacOS/VLC"
 
   zap trash: [
     "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.videolan.vlc.sfl*",


### PR DESCRIPTION
### Description
Migrate all legacy `preflight`, `postflight`, and `uninstall_preflight` blocks across the tap to canonical Homebrew install steps DSL:

- Migrate `preflight` with `xattr` to `preflight_steps` (15 casks)
- Replace manual wrapper scripts with `command_wrapper` (Blender, GIMP, OBS, VLC, Inkscape)
- Update `miniforge-cn` to use declarative `postflight_steps` and `uninstall_preflight_steps`

Eliminates all `Warning: Calling preflight/postflight is deprecated! Use preflight_steps/postflight_steps instead.` warnings during `brew update`.

Closes #1455